### PR TITLE
Allow to set an option to hide the Use default on helpsite field

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -948,7 +948,9 @@
 			name="helpurl"
 			type="helpsite"
 			label="COM_CONFIG_FIELD_HELP_SERVER_LABEL"
-			description="COM_CONFIG_FIELD_HELP_SERVER_DESC" />
+			description="COM_CONFIG_FIELD_HELP_SERVER_DESC"
+			showDefault="false"
+		/>
 	</fieldset>
 
 	<fieldset

--- a/administrator/components/com_users/controllers/profile.json.php
+++ b/administrator/components/com_users/controllers/profile.json.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package     Joomla.Site
+ * @package     Joomla.Administrator
  * @subpackage  com_users
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
@@ -14,7 +14,7 @@ require_once JPATH_SITE . '/components/com_users/controllers/profile_base_json.p
 /**
  * Profile controller class for Users.
  *
- * @since  1.6
+ * @since  3.5
  */
 class UsersControllerProfile extends UsersControllerProfile_Base_Json
 {

--- a/administrator/help/helpsites.xml
+++ b/administrator/help/helpsites.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <joshelp>
 	<sites>
-		<site
-			tag="en-GB"
-			url="https://help.joomla.org/proxy/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">English (GB) - Joomla help wiki</site>
-		<site
-			tag="fr-FR"
-			url="http://help.joomla.fr/3/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
+		<site tag="en-GB" url="https://help.joomla.org/proxy/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">English (GB) - Joomla help wiki</site>
+		<site tag="fr-FR" url="http://help.joomla.fr/3/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
 	</sites>
 </joshelp>

--- a/components/com_users/controllers/profile_base_json.php
+++ b/components/com_users/controllers/profile_base_json.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_users
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Profile controller class for Users.
+ *
+ * @since  3.5
+ */
+class UsersControllerProfile_Base_Json extends JControllerLegacy
+{
+	/**
+	 * Returns the updated options for help site selector
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5
+	 * @throws  Exception
+	 */
+	public function gethelpsites()
+	{
+		jimport('joomla.filesystem.file');
+
+		// Set FTP credentials, if given
+		JClientHelper::setCredentialsFromRequest('ftp');
+
+		if (($data = file_get_contents('http://update.joomla.org/helpsites/helpsites.xml')) === false)
+		{
+			throw new Exception(JText::_('COM_CONFIG_ERROR_HELPREFRESH_FETCH'), 500);
+		}
+		elseif (!JFile::write(JPATH_ADMINISTRATOR . '/help/helpsites.xml', $data))
+		{
+			throw new Exception(JText::_('COM_CONFIG_ERROR_HELPREFRESH_ERROR_STORE'), 500);
+		}
+
+		$options = array_merge(
+			array(
+				JHtml::_('select.option', '', JText::_('JOPTION_USE_DEFAULT'))
+			),
+			JHelp::createSiteList(JPATH_ADMINISTRATOR . '/help/helpsites.xml')
+		);
+
+		echo json_encode($options);
+		JFactory::getApplication()->close();
+	}
+}

--- a/libraries/cms/form/field/helpsite.php
+++ b/libraries/cms/form/field/helpsite.php
@@ -56,12 +56,15 @@ class JFormFieldHelpsite extends JFormFieldList
 			'var helpsite_base = "' . addslashes(JUri::root()) . '";'
 		);
 
+		$showDefault = $this->getAttribute('showDefault') === 'false' ? 'false' : 'true';
+
 		$html = parent::getInput();
 		$button = '<button
 						type="button"
 						class="btn btn-small"
 						id="helpsite-refresh"
 						rel="' . $this->id . '"
+						showDefault="' . $showDefault . '"
 					>
 					<span>' . JText::_('JGLOBAL_HELPREFRESH_BUTTON') . '</span>
 					</button>';

--- a/libraries/cms/form/field/helpsite.php
+++ b/libraries/cms/form/field/helpsite.php
@@ -52,9 +52,6 @@ class JFormFieldHelpsite extends JFormFieldList
 	protected function getInput()
 	{
 		JHtml::script('system/helpsite.js', false, true);
-		JFactory::getDocument()->addScriptDeclaration(
-			'var helpsite_base = "' . addslashes(JUri::root()) . '";'
-		);
 
 		$showDefault = $this->getAttribute('showDefault') === 'false' ? 'false' : 'true';
 

--- a/media/system/js/helpsite.js
+++ b/media/system/js/helpsite.js
@@ -14,7 +14,7 @@ jQuery(document).ready(function() {
 		var select_id   = jQuery(this).attr('rel');
 		var showDefault = jQuery(this).attr('showDefault');
 
-		jQuery.getJSON(helpsite_base + 'index.php?option=com_users&task=profile.gethelpsites&format=json', function(data){
+		jQuery.getJSON('index.php?option=com_users&task=profile.gethelpsites&format=json', function(data){
 			// The response contains the options to use in help site select field
 			var items = [];
 

--- a/media/system/js/helpsite.js
+++ b/media/system/js/helpsite.js
@@ -11,14 +11,18 @@ jQuery(document).ready(function() {
 	jQuery('#helpsite-refresh').click(function()
 	{
 		// Uses global variable helpsite_base for bast uri
-		var select_id = jQuery(this).attr('rel');
+		var select_id   = jQuery(this).attr('rel');
+		var showDefault = jQuery(this).attr('showDefault');
+
 		jQuery.getJSON(helpsite_base + 'index.php?option=com_users&task=profile.gethelpsites&format=json', function(data){
 			// The response contains the options to use in help site select field
 			var items = [];
 
 			// Build options
 			jQuery.each(data, function(key, val) {
-				items.push('<option value="' + val.value + '">' + val.text + '</option>');
+				if (val.value !== '' || showDefault === 'true') {
+					items.push('<option value="' + val.value + '">' + val.text + '</option>');
+				}
 			});
 
 			// Replace current select options. The trigger is needed for Chosen select box enhancer


### PR DESCRIPTION
This will hide the default option for main configuration and keep it for other managements.
